### PR TITLE
[FEAT] CoreData CRUD 구현

### DIFF
--- a/JGDDMembership/JGDDMembership.xcodeproj/project.pbxproj
+++ b/JGDDMembership/JGDDMembership.xcodeproj/project.pbxproj
@@ -6,8 +6,15 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		9229D8542CC64DBD00FD0EB6 /* ProfileMO+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9229D8522CC64DBD00FD0EB6 /* ProfileMO+CoreDataClass.swift */; };
+		9229D8552CC64DBD00FD0EB6 /* ProfileMO+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9229D8532CC64DBD00FD0EB6 /* ProfileMO+CoreDataProperties.swift */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXFileReference section */
 		9229D7FC2CC638FA00FD0EB6 /* JGDDMembership.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JGDDMembership.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9229D8522CC64DBD00FD0EB6 /* ProfileMO+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProfileMO+CoreDataClass.swift"; sourceTree = "<group>"; };
+		9229D8532CC64DBD00FD0EB6 /* ProfileMO+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProfileMO+CoreDataProperties.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -45,6 +52,8 @@
 		9229D7F32CC638FA00FD0EB6 = {
 			isa = PBXGroup;
 			children = (
+				9229D8522CC64DBD00FD0EB6 /* ProfileMO+CoreDataClass.swift */,
+				9229D8532CC64DBD00FD0EB6 /* ProfileMO+CoreDataProperties.swift */,
 				9229D7FE2CC638FA00FD0EB6 /* JGDDMembership */,
 				9229D7FD2CC638FA00FD0EB6 /* Products */,
 			);
@@ -132,6 +141,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9229D8542CC64DBD00FD0EB6 /* ProfileMO+CoreDataClass.swift in Sources */,
+				9229D8552CC64DBD00FD0EB6 /* ProfileMO+CoreDataProperties.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JGDDMembership/JGDDMembership/Applicaton/AppDelegate.swift
+++ b/JGDDMembership/JGDDMembership/Applicaton/AppDelegate.swift
@@ -10,7 +10,15 @@ import CoreData
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
+    lazy var container: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "Profile")
+        container.loadPersistentStores { _, error in
+            if let error = error {
+                fatalError("Unable to load persistent stores: \(error)")
+            }
+        }
+        return container
+    }()
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {

--- a/JGDDMembership/JGDDMembership/Applicaton/AppDelegate.swift
+++ b/JGDDMembership/JGDDMembership/Applicaton/AppDelegate.swift
@@ -20,7 +20,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return container
     }()
 
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true

--- a/JGDDMembership/JGDDMembership/Applicaton/SceneDelegate.swift
+++ b/JGDDMembership/JGDDMembership/Applicaton/SceneDelegate.swift
@@ -11,7 +11,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
@@ -20,4 +19,3 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = ViewController()
     }
 }
-

--- a/JGDDMembership/JGDDMembership/Error/ModelError.swift
+++ b/JGDDMembership/JGDDMembership/Error/ModelError.swift
@@ -1,0 +1,13 @@
+//
+//  ModelError.swift
+//  JGDDMembership
+//
+//  Created by minsong kim on 10/21/24.
+//
+
+import Foundation
+
+enum ModelError: Error {
+    case bindingError(String)
+    case failureError(String)
+}

--- a/JGDDMembership/JGDDMembership/Model/JGDDMembership.xcdatamodeld/JGDDMembership.xcdatamodel/contents
+++ b/JGDDMembership/JGDDMembership/Model/JGDDMembership.xcdatamodeld/JGDDMembership.xcdatamodel/contents
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
-    <elements/>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23231" systemVersion="24A348" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="ProfileMO" representedClassName="ProfileMO" syncable="YES">
+        <attribute name="greeting" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="image" optional="YES" attributeType="String"/>
+        <attribute name="mbti" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+    </entity>
 </model>

--- a/JGDDMembership/JGDDMembership/Protocol/CoreDataManageable.swift
+++ b/JGDDMembership/JGDDMembership/Protocol/CoreDataManageable.swift
@@ -1,0 +1,102 @@
+//
+//  CoreDataManageable.swift
+//  JGDDMembership
+//
+//  Created by minsong kim on 10/21/24.
+//
+
+import CoreData
+import UIKit
+
+protocol CoreDataManageable {
+    var container: NSPersistentContainer { get }
+}
+
+extension CoreDataManageable {
+    func createCoreData(image: String, name: String, greeting: String, mbti: String) throws {
+        //저장할 Entity 가져오기
+        guard let entity = NSEntityDescription.entity(forEntityName: "Profile", in: container.viewContext) else {
+            throw ModelError.bindingError("saveCoreData")
+        }
+        
+        //해당 entity에 저장할 NSManagedObject를 생성
+        let object = NSManagedObject(entity: entity, insertInto: container.viewContext)
+        
+        //그 안에 정보들을 저장.
+        object.setValue(UUID(), forKey: "id")
+        object.setValue(image, forKey: "image")
+        object.setValue(name, forKey: "name")
+        object.setValue(greeting, forKey: "greeting")
+        object.setValue(mbti, forKey: "mbti")
+        
+        //저장
+        do {
+            try container.viewContext.save()
+        } catch {
+            throw ModelError.failureError("saveCoreData")
+        }
+    }
+    
+    func readCoreData() throws -> [ProfileMO] {
+        do {
+            return try container.viewContext.fetch(ProfileMO.fetchRequest())
+        } catch {
+            throw ModelError.failureError("readCoreData")
+        }
+    }
+    
+    func updateCoreData(_ data: ProfileMO) throws {
+        let fetchRequest = ProfileMO.fetchRequest()
+        
+        guard let id = data.id else {
+            throw ModelError.bindingError("dataBinding")
+        }
+        
+        //predicate를 통해 특정한 객체만 가져오도록 설정한다. UUID는 유일하게 가지고 있다고 볼 수 있기에 이를 사용한다.
+        fetchRequest.predicate = NSPredicate(format: "id = %@", id as CVarArg)
+        
+        //만들어 두었던 fetchRequest를 통해 fetch한다. fetch된 결과물이 배열이기에 첫번째 것을 가져다가 사용한다.
+        guard let result = try? container.viewContext.fetch(fetchRequest),
+              let object = result.first else {
+            throw ModelError.bindingError("updateCoreData")
+        }
+        
+        //값 수정.(업데이트)
+        object.setValue(data.image, forKey: "image")
+        object.setValue(data.name, forKey: "name")
+        object.setValue(data.greeting, forKey: "greeting")
+        object.setValue(data.mbti, forKey: "mbti")
+        
+        //수정한 내용 저장
+        do {
+            try container.viewContext.save()
+        } catch {
+            throw ModelError.failureError("updateCoreData")
+        }
+    }
+    
+    func deleteCoreData(_ data: ProfileMO) throws {
+        //update와 같다.
+        let fetchRequest = ProfileMO.fetchRequest()
+        guard let id = data.id else {
+            throw ModelError.bindingError("dataBinding")
+        }
+        
+        fetchRequest.predicate = NSPredicate(format: "id = %@", id as CVarArg)
+        
+        guard let result = try? container.viewContext.fetch(fetchRequest),
+              let object = result.first else {
+            throw ModelError.bindingError("deleteCoreData")
+        }
+        
+        //찾은 객체를 삭제한다.
+        container.viewContext.delete(object)
+            
+        //삭제했다는 것을 저장한다.
+        do {
+            try container.viewContext.save()
+        } catch {
+            throw ModelError.failureError("deleteCoreData")
+        }
+    }
+}

--- a/JGDDMembership/JGDDMembership/Protocol/CoreDataManageable.swift
+++ b/JGDDMembership/JGDDMembership/Protocol/CoreDataManageable.swift
@@ -14,22 +14,18 @@ protocol CoreDataManageable {
 
 extension CoreDataManageable {
     func createCoreData(image: String, name: String, greeting: String, mbti: String) throws {
-        //저장할 Entity 가져오기
         guard let entity = NSEntityDescription.entity(forEntityName: "Profile", in: container.viewContext) else {
             throw ModelError.bindingError("saveCoreData")
         }
         
-        //해당 entity에 저장할 NSManagedObject를 생성
         let object = NSManagedObject(entity: entity, insertInto: container.viewContext)
         
-        //그 안에 정보들을 저장.
         object.setValue(UUID(), forKey: "id")
         object.setValue(image, forKey: "image")
         object.setValue(name, forKey: "name")
         object.setValue(greeting, forKey: "greeting")
         object.setValue(mbti, forKey: "mbti")
         
-        //저장
         do {
             try container.viewContext.save()
         } catch {
@@ -52,22 +48,18 @@ extension CoreDataManageable {
             throw ModelError.bindingError("dataBinding")
         }
         
-        //predicate를 통해 특정한 객체만 가져오도록 설정한다. UUID는 유일하게 가지고 있다고 볼 수 있기에 이를 사용한다.
         fetchRequest.predicate = NSPredicate(format: "id = %@", id as CVarArg)
         
-        //만들어 두었던 fetchRequest를 통해 fetch한다. fetch된 결과물이 배열이기에 첫번째 것을 가져다가 사용한다.
         guard let result = try? container.viewContext.fetch(fetchRequest),
               let object = result.first else {
             throw ModelError.bindingError("updateCoreData")
         }
         
-        //값 수정.(업데이트)
         object.setValue(data.image, forKey: "image")
         object.setValue(data.name, forKey: "name")
         object.setValue(data.greeting, forKey: "greeting")
         object.setValue(data.mbti, forKey: "mbti")
         
-        //수정한 내용 저장
         do {
             try container.viewContext.save()
         } catch {
@@ -76,7 +68,6 @@ extension CoreDataManageable {
     }
     
     func deleteCoreData(_ data: ProfileMO) throws {
-        //update와 같다.
         let fetchRequest = ProfileMO.fetchRequest()
         guard let id = data.id else {
             throw ModelError.bindingError("dataBinding")
@@ -89,10 +80,8 @@ extension CoreDataManageable {
             throw ModelError.bindingError("deleteCoreData")
         }
         
-        //찾은 객체를 삭제한다.
         container.viewContext.delete(object)
             
-        //삭제했다는 것을 저장한다.
         do {
             try container.viewContext.save()
         } catch {

--- a/JGDDMembership/ProfileMO+CoreDataClass.swift
+++ b/JGDDMembership/ProfileMO+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  ProfileMO+CoreDataClass.swift
+//  JGDDMembership
+//
+//  Created by minsong kim on 10/21/24.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(ProfileMO)
+public class ProfileMO: NSManagedObject {
+
+}

--- a/JGDDMembership/ProfileMO+CoreDataProperties.swift
+++ b/JGDDMembership/ProfileMO+CoreDataProperties.swift
@@ -1,0 +1,29 @@
+//
+//  ProfileMO+CoreDataProperties.swift
+//  JGDDMembership
+//
+//  Created by minsong kim on 10/21/24.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension ProfileMO {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ProfileMO> {
+        return NSFetchRequest<ProfileMO>(entityName: "ProfileMO")
+    }
+
+    @NSManaged public var image: String?
+    @NSManaged public var name: String?
+    @NSManaged public var greeting: String?
+    @NSManaged public var mbti: String?
+    @NSManaged public var id: UUID?
+
+}
+
+extension ProfileMO : Identifiable {
+
+}


### PR DESCRIPTION
## 📚 작업 설명
- CoreData로 CRUD 구현.
- 앱을 관리하는 AppDelegate에서 Container 생성.
- CoreDataManageable을 ViewController에서 채택하여 사용할 수 있도록 구현.
- ViewController에서 AppDelegate에 구현된 Container를 가져와 사용할 수 있도록 구현.
- CRUD 과정에서 생기는 Error 들은 ModelError의 BindingError, FailureError로 구분하여 throw.